### PR TITLE
Problema na inicialização do DBAccess

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,11 +31,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 	# apos iniciar o servidor, subir o dbaccess
 	postgres.trigger.after :up do |trigger|
-      trigger.warn = "Iniciando Banco de dados"
-      trigger.run_remote = {inline: "sudo systemctl start init-dbaccess.service"}
-      trigger.run_remote = {inline: "sudo setenforce 0"}
-	  trigger.run_remote = {inline: "ping 192.168.56.20 -c 10"}
-    end
+      		trigger.warn = "Iniciando Banco de dados"
+      		trigger.run_remote = {inline: "sudo systemctl start init-dbaccess.service"}
+	end
+      		#trigger.run_remote = {inline: "sudo setenforce 0"}
+	  	#trigger.run_remote = {inline: "ping 192.168.56.20 -c 10"}
+    	#end
 	
 	# antes de destruir a maquina, tirar um backup do banco
 	postgres.trigger.before :destroy do |trigger|


### PR DESCRIPTION
Foram comentadas as linhas para que o DBAccess fosse inicializado sem erros, pois o setenforce = 0 já deve estar definido no arquivo de inicialização do SO